### PR TITLE
docs: explicitly require difft --color=always command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ return {
   },
   config = function()
     require("difft").setup({
-      command = "jj diff --no-pager",  -- or "git diff"
+      command = "jj diff --no-pager",  -- or "GIT_EXTERNAL_DIFF='difft --color=always' git diff"
       layout = "float",  -- nil (buffer), "float", or "ivy_taller"
     })
   end,
@@ -369,3 +369,17 @@ nvim -l tests/run.lua
 ```
 
 See [tests/README.md](./tests/README.md) for details.
+
+## Troubleshooting
+
+### No colors visible in diff output
+
+Ensure that the `difft` command is called with the `--color=always` flag. You can customize the command in the setup:
+
+```lua
+require("difft").setup({
+  command = "GIT_EXTERNAL_DIFF='difft --color=always' git diff",
+})
+```
+
+`difft.nvim` relies on ANSI color codes to render colored diffs. These codes must be inserted by `difft`.


### PR DESCRIPTION
Problem: I had trouble getting highlights to show up in the diff buffer. I only later discovered that I had to force difft to use colors in the output. It was not obvious, even though I set `GIT_EXTERNAL_DIFF=difft` initially in the `command` in the `setup` method.

Solution: Make it clear in the README to use `difft --color=always` as the `GIT_EXTERNAL_DIFF` environment variable.

I only modified the `git diff` command. I haven't modified the `jj` command since I am not using `jj`