### PR TITLE
fix: change default command from jj to git

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ return {
   },
   config = function()
     require("difft").setup({
-      command = "jj diff --no-pager",  -- or "GIT_EXTERNAL_DIFF='difft --color=always' git diff"
+      command = "GIT_EXTERNAL_DIFF='difft --color=always' git diff",  -- or "jj diff --no-pager"
       layout = "float",  -- nil (buffer), "float", or "ivy_taller"
     })
   end,
@@ -349,7 +349,7 @@ require("difft").setup({
 ### Other Options
 
 ```lua
-command = "jj diff --no-pager"  -- Diff command to execute
+command = "GIT_EXTERNAL_DIFF='difft --color=always' git diff"  -- Diff command to execute
 auto_jump = true                 -- Jump to first change on open
 no_diff_message = "No changes found"
 loading_message = "Loading diff..."

--- a/lua/difft/init.lua
+++ b/lua/difft/init.lua
@@ -42,7 +42,7 @@ local config = {
 		relativenumber = false,
 		border = "rounded",
 	},
-	command = "jj diff --no-pager",
+	command = "GIT_EXTERNAL_DIFF='difft --color=always' git diff",
 	auto_jump = true,
 	layout = nil,
 	no_diff_message = "No changes found",


### PR DESCRIPTION
Replace default command with GIT_EXTERNAL_DIFF git command to work for most users Update README examples to show git as primary with jj as alternative Fixes issue where default assumed jujutsu installed